### PR TITLE
Add Qwen3-VL 4B caption model

### DIFF
--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -26,7 +26,10 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
             caption_prefix: str = "",
             caption_postfix: str = "",
     ) -> str:
-        prompt = initial_caption if initial_caption else "Describe this image only."
+        prompt = initial_caption if initial_caption else (
+            "Describe the image. Output only the description, with no introduction, "
+            "explanation, or conversational filler."
+        )
 
         messages = [
             {

--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -56,7 +56,7 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
         generated_ids_trimmed = [
             out_ids[len(in_ids):]
             for in_ids, out_ids
-            in zip(inputs.input_ids, generated_ids)
+            in zip(inputs.input_ids, generated_ids, strict=True)
         ]
         predicted_caption = self.processor.batch_decode(
             generated_ids_trimmed,

--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -60,8 +60,6 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
             skip_special_tokens=True,
             clean_up_tokenization_spaces=False,
         )[0].strip()
-        predicted_caption = (
-            caption_prefix + initial_caption + predicted_caption + caption_postfix
-        ).strip()
+        predicted_caption = (caption_prefix + predicted_caption + caption_postfix).strip()
 
         return predicted_caption

--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -7,8 +7,8 @@ from transformers import AutoModelForImageTextToText, AutoProcessor
 
 class Qwen3VL4BModel(BaseImageCaptionModel):
     def __init__(self, device: torch.device, dtype: torch.dtype):
-        self.device = device
-        self.dtype = dtype
+        self.device = self.__supported_device(device)
+        self.dtype = self.__supported_dtype(self.device, dtype)
         self.model_id = "Qwen/Qwen3-VL-4B-Instruct"
 
         self.processor = AutoProcessor.from_pretrained(self.model_id)
@@ -18,6 +18,44 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
         )
         self.model.eval()
         self.model.to(self.device)
+
+    @staticmethod
+    def __supported_device(device: torch.device) -> torch.device:
+        if device.type == "cuda":
+            if not torch.cuda.is_available():
+                print("CUDA is not available. Loading Qwen3-VL 4B on CPU instead.")
+                return torch.device("cpu")
+
+            if device.index is not None and device.index >= torch.cuda.device_count():
+                print(f"CUDA device {device} is not available. Loading Qwen3-VL 4B on CPU instead.")
+                return torch.device("cpu")
+
+        if device.type == "mps" and not torch.backends.mps.is_available():
+            print("MPS is not available. Loading Qwen3-VL 4B on CPU instead.")
+            return torch.device("cpu")
+
+        return device
+
+    @staticmethod
+    def __supported_dtype(device: torch.device, dtype: torch.dtype) -> torch.dtype:
+        if device.type == "cpu":
+            return torch.float32
+
+        if device.type == "cuda":
+            if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+                return torch.float16
+            if dtype in (torch.float16, torch.bfloat16, torch.float32):
+                return dtype
+            return torch.float16
+
+        if device.type == "mps":
+            if dtype in (torch.float16, torch.float32):
+                return dtype
+            return torch.float16
+
+        if dtype in (torch.float16, torch.bfloat16, torch.float32):
+            return dtype
+        return torch.float32
 
     def generate_caption(
             self,

--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -8,7 +8,7 @@ from transformers import AutoModelForImageTextToText, AutoProcessor
 class Qwen3VL4BModel(BaseImageCaptionModel):
     def __init__(self, device: torch.device, dtype: torch.dtype):
         self.device = device
-        self.dtype = self.__supported_dtype(device, dtype)
+        self.dtype = dtype
         self.model_id = "Qwen/Qwen3-VL-4B-Instruct"
 
         self.processor = AutoProcessor.from_pretrained(self.model_id)
@@ -18,22 +18,6 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
         )
         self.model.eval()
         self.model.to(self.device)
-
-    @staticmethod
-    def __supported_dtype(device: torch.device, dtype: torch.dtype) -> torch.dtype:
-        if device.type == "cuda":
-            if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
-                return torch.float16
-            if dtype in (torch.float16, torch.bfloat16, torch.float32):
-                return dtype
-            return torch.float16
-
-        if device.type == "mps":
-            if dtype in (torch.float16, torch.float32):
-                return dtype
-            return torch.float16
-
-        return dtype
 
     def generate_caption(
             self,

--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -1,0 +1,72 @@
+from modules.module.BaseImageCaptionModel import BaseImageCaptionModel, CaptionSample
+
+import torch
+
+from transformers import AutoModelForImageTextToText, AutoProcessor
+
+
+class Qwen3VL4BModel(BaseImageCaptionModel):
+    def __init__(self, device: torch.device, dtype: torch.dtype):
+        self.device = device
+        self.dtype = dtype
+        self.model_id = "Qwen/Qwen3-VL-4B-Instruct"
+
+        self.processor = AutoProcessor.from_pretrained(self.model_id)
+        self.model = AutoModelForImageTextToText.from_pretrained(
+            self.model_id,
+            torch_dtype=self.dtype,
+        )
+        self.model.eval()
+        self.model.to(self.device)
+
+    def generate_caption(
+            self,
+            caption_sample: CaptionSample,
+            initial_caption: str = "",
+            caption_prefix: str = "",
+            caption_postfix: str = "",
+    ) -> str:
+        prompt = "Describe this image in one concise caption."
+        if initial_caption:
+            prompt = (
+                "Continue this image caption with concise visual details. "
+                f"Only provide the continuation, without repeating this prefix: {initial_caption}"
+            )
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": caption_sample.get_image()},
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ]
+
+        inputs = self.processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        inputs = inputs.to(self.device)
+
+        with torch.no_grad():
+            generated_ids = self.model.generate(**inputs, max_new_tokens=128)
+
+        generated_ids_trimmed = [
+            out_ids[len(in_ids):]
+            for in_ids, out_ids
+            in zip(inputs.input_ids, generated_ids)
+        ]
+        predicted_caption = self.processor.batch_decode(
+            generated_ids_trimmed,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )[0].strip()
+        predicted_caption = (
+            caption_prefix + initial_caption + predicted_caption + caption_postfix
+        ).strip()
+
+        return predicted_caption

--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -7,8 +7,8 @@ from transformers import AutoModelForImageTextToText, AutoProcessor
 
 class Qwen3VL4BModel(BaseImageCaptionModel):
     def __init__(self, device: torch.device, dtype: torch.dtype):
-        self.device = self.__supported_device(device)
-        self.dtype = self.__supported_dtype(self.device, dtype)
+        self.device = device
+        self.dtype = self.__supported_dtype(device, dtype)
         self.model_id = "Qwen/Qwen3-VL-4B-Instruct"
 
         self.processor = AutoProcessor.from_pretrained(self.model_id)
@@ -20,27 +20,7 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
         self.model.to(self.device)
 
     @staticmethod
-    def __supported_device(device: torch.device) -> torch.device:
-        if device.type == "cuda":
-            if not torch.cuda.is_available():
-                print("CUDA is not available. Loading Qwen3-VL 4B on CPU instead.")
-                return torch.device("cpu")
-
-            if device.index is not None and device.index >= torch.cuda.device_count():
-                print(f"CUDA device {device} is not available. Loading Qwen3-VL 4B on CPU instead.")
-                return torch.device("cpu")
-
-        if device.type == "mps" and not torch.backends.mps.is_available():
-            print("MPS is not available. Loading Qwen3-VL 4B on CPU instead.")
-            return torch.device("cpu")
-
-        return device
-
-    @staticmethod
     def __supported_dtype(device: torch.device, dtype: torch.dtype) -> torch.dtype:
-        if device.type == "cpu":
-            return torch.float32
-
         if device.type == "cuda":
             if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
                 return torch.float16
@@ -53,9 +33,7 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
                 return dtype
             return torch.float16
 
-        if dtype in (torch.float16, torch.bfloat16, torch.float32):
-            return dtype
-        return torch.float32
+        return dtype
 
     def generate_caption(
             self,

--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -26,12 +26,7 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
             caption_prefix: str = "",
             caption_postfix: str = "",
     ) -> str:
-        prompt = "Describe this image in one concise caption."
-        if initial_caption:
-            prompt = (
-                "Continue this image caption with concise visual details. "
-                f"Only provide the continuation, without repeating this prefix: {initial_caption}"
-            )
+        prompt = initial_caption
 
         messages = [
             {
@@ -53,7 +48,7 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
         inputs = inputs.to(self.device)
 
         with torch.no_grad():
-            generated_ids = self.model.generate(**inputs, max_new_tokens=128)
+            generated_ids = self.model.generate(**inputs)
 
         generated_ids_trimmed = [
             out_ids[len(in_ids):]

--- a/modules/module/Qwen3VL4BModel.py
+++ b/modules/module/Qwen3VL4BModel.py
@@ -26,7 +26,7 @@ class Qwen3VL4BModel(BaseImageCaptionModel):
             caption_prefix: str = "",
             caption_postfix: str = "",
     ) -> str:
-        prompt = initial_caption
+        prompt = initial_caption if initial_caption else "Describe this image only."
 
         messages = [
             {

--- a/modules/ui/CaptionUIController.py
+++ b/modules/ui/CaptionUIController.py
@@ -6,6 +6,7 @@ from modules.module.Blip2Model import Blip2Model
 from modules.module.BlipModel import BlipModel
 from modules.module.ClipSegModel import ClipSegModel
 from modules.module.MaskByColor import MaskByColor
+from modules.module.Qwen3VL4BModel import Qwen3VL4BModel
 from modules.module.RembgHumanModel import RembgHumanModel
 from modules.module.RembgModel import RembgModel
 from modules.module.WDModel import WDModel
@@ -342,6 +343,10 @@ class CaptionUIController:
             self._release_models()
             print("loading Blip2 model, this may take a while")
             self.captioning_model = Blip2Model(default_device, torch.float16)
+        elif model == "Qwen3-VL 4B" and model_type != "Qwen3VL4BModel":
+            self._release_models()
+            print("loading Qwen3-VL 4B model, this may take a while")
+            self.captioning_model = Qwen3VL4BModel(default_device, torch.float16)
         elif model == "WD14 VIT v2" and model_type != "WDModel":
             self._release_models()
             print("loading WD14_VIT_v2 model, this may take a while")

--- a/modules/ui/CtkGenerateCaptionsWindowView.py
+++ b/modules/ui/CtkGenerateCaptionsWindowView.py
@@ -21,7 +21,7 @@ class CtkGenerateCaptionsWindowView(BaseGenerateCaptionsWindowView, ctk.CTkTople
         self.mode_var = ctk.StringVar(self, "Create if absent")
         self.modes = ["Replace all captions", "Create if absent", "Add as new line"]
         self.model_var = ctk.StringVar(self, "Blip")
-        self.models = ["Blip", "Blip2", "WD14 VIT v2"]
+        self.models = ["Blip", "Blip2", "Qwen3-VL 4B", "WD14 VIT v2"]
 
         self.title("Batch generate captions")
         self.geometry("360x360")

--- a/modules/ui/PySide6GenerateCaptionsWindowView.py
+++ b/modules/ui/PySide6GenerateCaptionsWindowView.py
@@ -21,7 +21,7 @@ class CtkGenerateCaptionsWindowView(BaseGenerateCaptionsWindowView, ctk.CTkTople
         self.mode_var = ctk.StringVar(self, "Create if absent")
         self.modes = ["Replace all captions", "Create if absent", "Add as new line"]
         self.model_var = ctk.StringVar(self, "Blip")
-        self.models = ["Blip", "Blip2", "WD14 VIT v2"]
+        self.models = ["Blip", "Blip2", "Qwen3-VL 4B", "WD14 VIT v2"]
 
         self.title("Batch generate captions")
         self.geometry("360x360")

--- a/modules/util/enum/GenerateCaptionsModel.py
+++ b/modules/util/enum/GenerateCaptionsModel.py
@@ -4,6 +4,7 @@ from enum import Enum
 class GenerateCaptionsModel(Enum):
     BLIP = 'BLIP'
     BLIP2 = 'BLIP2'
+    QWEN3VL_4B = 'QWEN3VL_4B'
     WD14_VIT_2 = 'WD14_VIT_2'
 
     def __str__(self):

--- a/scripts/generate_captions.py
+++ b/scripts/generate_captions.py
@@ -4,6 +4,7 @@ script_imports()
 
 from modules.module.Blip2Model import Blip2Model
 from modules.module.BlipModel import BlipModel
+from modules.module.Qwen3VL4BModel import Qwen3VL4BModel
 from modules.module.WDModel import WDModel
 from modules.util.args.GenerateCaptionsArgs import GenerateCaptionsArgs
 from modules.util.enum.GenerateCaptionsModel import GenerateCaptionsModel
@@ -19,6 +20,8 @@ def main():
         model = BlipModel(torch.device(args.device), args.dtype.torch_dtype())
     elif args.model == GenerateCaptionsModel.BLIP2:
         model = Blip2Model(torch.device(args.device), args.dtype.torch_dtype())
+    elif args.model == GenerateCaptionsModel.QWEN3VL_4B:
+        model = Qwen3VL4BModel(torch.device(args.device), args.dtype.torch_dtype())
     elif args.model == GenerateCaptionsModel.WD14_VIT_2:
         model = WDModel(torch.device(args.device), args.dtype.torch_dtype())
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `Qwen3VL4BModel` as a `BaseImageCaptionModel` implementation using `Qwen/Qwen3-VL-4B-Instruct`.
- Uses the provided `initial_caption` directly as the Qwen3-VL prompt when present, and falls back to an instruction to describe the image while outputting only the description when it is empty.
- Does not append `initial_caption` to the returned caption.
- Leaves Qwen3-VL generation length uncapped by this wrapper.
- Uses the caller-provided device and dtype directly, relying on existing outer validation/selection.
- Wires `QWEN3VL_4B` into the caption generation CLI.
- Adds `Qwen3-VL 4B` to the batch caption UI model selector and controller loading path.

## Test plan

- [x] `python3 -m compileall -q .`
- [x] `python3 -m pre_commit run --all-files`
- [x] `python3 scripts/generate_captions.py --help`
- [x] Import-level Qwen checks for `Qwen3VL4BModel`, `GenerateCaptionsModel.QWEN3VL_4B`, `AutoModelForImageTextToText`, and `AutoProcessor`
- [x] Full direct Qwen3-VL caption run on a local generated test image: `python3 scripts/generate_captions.py --model QWEN3VL_4B --sample-dir /tmp/onetrainer-qwen-caption-test --device cpu --dtype FLOAT_16`
  - Output caption: `A blue rectangle with a yellow circle positioned above its top center.`
  - Note: run completed on this Linux cloud runner's CPU because CUDA/MPS were unavailable here.
- [x] Focused source assertions confirmed tightened empty prompt fallback, strict generated-id trimming, no `max_new_tokens`, no `initial_caption` in output assembly, and direct caller dtype usage
- [x] Tested with at least one real preset / config when relevant (not relevant)

## AI assistance

- AI-assisted — I have read every line in this diff and can defend each change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5dc07a57-04ad-4fe2-a33b-587decc2b593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5dc07a57-04ad-4fe2-a33b-587decc2b593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

